### PR TITLE
std::snprintf needs cstdio included

### DIFF
--- a/src/Option/Exception.cpp
+++ b/src/Option/Exception.cpp
@@ -16,6 +16,7 @@
 #include "Option/Util.hpp"
 
 #include <cstdarg>
+#include <cstdio>
 
 
 //----------------------------------------------------------------------------|


### PR DESCRIPTION
Fixes clang 3.4 build again
